### PR TITLE
Rename to Peripheral Inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cortex Debug SVD Viewer
+# Embedded Peripheral Inspector
 
 Standalone SVD Viewer extension extracted from [cortex-debug](https://github.com/Marus/cortex-debug)
 
@@ -77,6 +77,6 @@ All variable key names used to extract data from debug launch configurations can
 
 The following list outlines the setting names and default values:
 
-- `svd-viewer.svdPathConfig` - Debug configuration key to use to get the SVD path (default `svdPath`)
-- `svd-viewer.deviceConfig` - Debug configuration key to use to get the device name (default: `deviceName`)
-- `svd-viewer.processorConfig` - Debug configuration key to use to get the processor name (default: `processorName`)
+- `peripheral-inspector.svdPathConfig` - Debug configuration key to use to get the SVD path (default `svdPath`)
+- `peripheral-inspector.deviceConfig` - Debug configuration key to use to get the device name (default: `deviceName`)
+- `peripheral-inspector.processorConfig` - Debug configuration key to use to get the processor name (default: `processorName`)

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Choose one of the following methods to specify your SVD file in your `launch.jso
 
 ### Use the CMSIS pack asset service
 
-Set the `svdPath` configuration variable to a qualified pack reference in the form `<vendor>::<device family pack>@<version>` e.g.:
+Set the `definitionPath` configuration variable to a qualified pack reference in the form `<vendor>::<device family pack>@<version>` e.g.:
 
 ```json
 {
     ...
-    "svdPath": "NXP::K32L3A60_DFP@15.0.0"
+    "definitionPath": "NXP::K32L3A60_DFP@15.0.0"
     ...
 }
 ```
@@ -25,7 +25,7 @@ If the pack supports multiple devices and/or processors, you will be prompted to
 ```json
 {
     ...
-    "svdPath": "NXP::K32L3A60_DFP@15.0.0",
+    "definitionPath": "NXP::K32L3A60_DFP@15.0.0",
     "deviceName": "K32L3A60VPJ1A",
     "processorName": "cm4"
     ...
@@ -37,7 +37,7 @@ __TIP:__ The pack reference and device name can be automatically derived if you 
 ```json
 {
     ...
-    "svdPath": "${command:device-manager.getDevicePack}",
+    "definitionPath": "${command:device-manager.getDevicePack}",
     "deviceName": "${command:device-manager.getDeviceName}"
     ...
 }
@@ -61,12 +61,12 @@ You can obtain an SVD file from a [CMSIS pack](https://developer.arm.com/tools-a
 
 Other vendors may ship SVD files when you install their software or device packs or you could write your own custom SVD file.
 
-Once you have the SVD file, specify the location of it in your `launch.json` using the `svdPath` variable:
+Once you have the SVD file, specify the location of it in your `launch.json` using the `definitionPath` variable:
 
 ```json
 {
     ...
-    "svdPath": "${workspaceFolder}/STM32F103.svd"
+    "definitionPath": "${workspaceFolder}/STM32F103.svd"
     ...
 }
 ```
@@ -77,6 +77,6 @@ All variable key names used to extract data from debug launch configurations can
 
 The following list outlines the setting names and default values:
 
-- `peripheral-inspector.svdPathConfig` - Debug configuration key to use to get the SVD path (default `svdPath`)
+- `peripheral-inspector.definitionPathConfig` - Debug configuration key to use to get the SVD path (default `definitionPath`)
 - `peripheral-inspector.deviceConfig` - Debug configuration key to use to get the device name (default: `deviceName`)
 - `peripheral-inspector.processorConfig` - Debug configuration key to use to get the processor name (default: `processorName`)

--- a/package.json
+++ b/package.json
@@ -248,10 +248,10 @@
     "configuration": {
       "title": "Peripheral Inspector",
       "properties": {
-        "peripheral-inspector.svdPathConfig": {
+        "peripheral-inspector.definitionPathConfig": {
           "type": "string",
-          "default": "svdPath",
-          "description": "Debug configuration key to use to get the SVD path"
+          "default": "definitionPath",
+          "description": "Debug configuration key to use to get the path for the definition file"
         },
         "peripheral-inspector.deviceConfig": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "svd-viewer",
-  "displayName": "SVD Viewer",
+  "name": "peripheral-inspector",
+  "displayName": "Peripheral Inspector",
   "description": "Standalone SVD Viewer extension extracted from cortex-debug",
   "version": "1.3.0",
   "preview": true,
@@ -65,45 +65,45 @@
     "views": {
       "debug": [
         {
-          "id": "svd-viewer.svd",
+          "id": "peripheral-inspector.svd",
           "name": "Peripherals",
-          "when": "svd-viewer.svd.hasData"
+          "when": "peripheral-inspector.svd.hasData"
         }
       ]
     },
     "commands": [
       {
-        "command": "svd-viewer.svd.updateNode",
+        "command": "peripheral-inspector.svd.updateNode",
         "title": "Update Value",
         "icon": "$(edit)"
       },
       {
-        "command": "svd-viewer.svd.copyValue",
+        "command": "peripheral-inspector.svd.copyValue",
         "title": "Copy Value",
         "icon": "$(files)"
       },
       {
-        "command": "svd-viewer.svd.forceRefresh",
+        "command": "peripheral-inspector.svd.forceRefresh",
         "title": "Refresh",
         "icon": "$(refresh)"
       },
       {
-        "command": "svd-viewer.svd.pin",
+        "command": "peripheral-inspector.svd.pin",
         "title": "Pin",
         "icon": "$(pin)"
       },
       {
-        "command": "svd-viewer.svd.unpin",
+        "command": "peripheral-inspector.svd.unpin",
         "title": "Unpin",
         "icon": "$(pinned)"
       },
       {
-        "command": "svd-viewer.svd.setFormat",
+        "command": "peripheral-inspector.svd.setFormat",
         "title": "Set Value Format",
         "icon": "$(symbol-unit)"
       },
       {
-        "command": "svd-viewer.svd.refreshAll",
+        "command": "peripheral-inspector.svd.refreshAll",
         "title": "Refresh All",
         "icon": "$(refresh)"
       }
@@ -111,164 +111,164 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "svd-viewer.svd.updateNode",
+          "command": "peripheral-inspector.svd.updateNode",
           "when": "false"
         },
         {
-          "command": "svd-viewer.svd.copyValue",
+          "command": "peripheral-inspector.svd.copyValue",
           "when": "false"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
+          "command": "peripheral-inspector.svd.forceRefresh",
           "when": "false"
         },
         {
-          "command": "svd-viewer.svd.pin",
+          "command": "peripheral-inspector.svd.pin",
           "when": "false"
         },
         {
-          "command": "svd-viewer.svd.unpin",
+          "command": "peripheral-inspector.svd.unpin",
           "when": "false"
         },
         {
-          "command": "svd-viewer.svd.setFormat",
+          "command": "peripheral-inspector.svd.setFormat",
           "when": "false"
         },
         {
-          "command": "svd-viewer.svd.refreshAll",
+          "command": "peripheral-inspector.svd.refreshAll",
           "when": "false"
         }
       ],
       "touchBar": [
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem == registerRW"
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem == registerRW"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem == register"
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem == register"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem == registerRO"
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem == registerRO"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem =~ /peripheral.*/"
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem =~ /peripheral.*/"
         },
         {
-          "command": "svd-viewer.svd.pin",
-          "when": "view == svd-viewer.svd && viewItem == peripheral"
+          "command": "peripheral-inspector.svd.pin",
+          "when": "view == peripheral-inspector.svd && viewItem == peripheral"
         },
         {
-          "command": "svd-viewer.svd.unpin",
-          "when": "view == svd-viewer.svd && viewItem == peripheral.pinned"
+          "command": "peripheral-inspector.svd.unpin",
+          "when": "view == peripheral-inspector.svd && viewItem == peripheral.pinned"
         }
       ],
       "view/title": [
         {
-          "command": "svd-viewer.svd.refreshAll",
-          "when": "view == svd-viewer.svd && debugState == stopped",
+          "command": "peripheral-inspector.svd.refreshAll",
+          "when": "view == peripheral-inspector.svd && debugState == stopped",
           "group": "navigation"
         }
       ],
       "view/item/context": [
         {
-          "command": "svd-viewer.svd.updateNode",
-          "when": "view == svd-viewer.svd && viewItem == field",
+          "command": "peripheral-inspector.svd.updateNode",
+          "when": "view == peripheral-inspector.svd && viewItem == field",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.updateNode",
-          "when": "view == svd-viewer.svd && viewItem == fieldWO",
+          "command": "peripheral-inspector.svd.updateNode",
+          "when": "view == peripheral-inspector.svd && viewItem == fieldWO",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.updateNode",
-          "when": "view == svd-viewer.svd && viewItem == registerRW",
+          "command": "peripheral-inspector.svd.updateNode",
+          "when": "view == peripheral-inspector.svd && viewItem == registerRW",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.copyValue",
-          "when": "view == svd-viewer.svd && viewItem == field",
+          "command": "peripheral-inspector.svd.copyValue",
+          "when": "view == peripheral-inspector.svd && viewItem == field",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.copyValue",
-          "when": "view == svd-viewer.svd && viewItem == fieldRO",
+          "command": "peripheral-inspector.svd.copyValue",
+          "when": "view == peripheral-inspector.svd && viewItem == fieldRO",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.copyValue",
-          "when": "view == svd-viewer.svd && viewItem == registerRW",
+          "command": "peripheral-inspector.svd.copyValue",
+          "when": "view == peripheral-inspector.svd && viewItem == registerRW",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.copyValue",
-          "when": "view == svd-viewer.svd && viewItem == registerRO",
+          "command": "peripheral-inspector.svd.copyValue",
+          "when": "view == peripheral-inspector.svd && viewItem == registerRO",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem == registerRW",
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem == registerRW",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem == register",
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem == register",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem == registerRO",
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem == registerRO",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.forceRefresh",
-          "when": "view == svd-viewer.svd && viewItem =~ /peripheral.*/",
+          "command": "peripheral-inspector.svd.forceRefresh",
+          "when": "view == peripheral-inspector.svd && viewItem =~ /peripheral.*/",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.pin",
-          "when": "view == svd-viewer.svd && viewItem == peripheral",
+          "command": "peripheral-inspector.svd.pin",
+          "when": "view == peripheral-inspector.svd && viewItem == peripheral",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.unpin",
-          "when": "view == svd-viewer.svd && viewItem == peripheral.pinned",
+          "command": "peripheral-inspector.svd.unpin",
+          "when": "view == peripheral-inspector.svd && viewItem == peripheral.pinned",
           "group": "inline"
         },
         {
-          "command": "svd-viewer.svd.setFormat",
-          "when": "view == svd-viewer.svd",
+          "command": "peripheral-inspector.svd.setFormat",
+          "when": "view == peripheral-inspector.svd",
           "group": "navigation"
         }
       ]
     },
     "configuration": {
-      "title": "SVD Viewer",
+      "title": "Peripheral Inspector",
       "properties": {
-        "svd-viewer.svdPathConfig": {
+        "peripheral-inspector.svdPathConfig": {
           "type": "string",
           "default": "svdPath",
           "description": "Debug configuration key to use to get the SVD path"
         },
-        "svd-viewer.deviceConfig": {
+        "peripheral-inspector.deviceConfig": {
           "type": "string",
           "default": "deviceName",
           "description": "Debug configuration key to use to get the device name"
         },
-        "svd-viewer.processorConfig": {
+        "peripheral-inspector.processorConfig": {
           "type": "string",
           "default": "processorName",
           "description": "Debug configuration key to use to get the processor name"
         },
-        "svd-viewer.packAssetUrl": {
+        "peripheral-inspector.packAssetUrl": {
           "type": "string",
           "default": "https://pack-content.cmsis.io",
           "description": "Base URL for CMSIS pack assets"
         },
-        "svd-viewer.svdAddrGapThreshold": {
+        "peripheral-inspector.svdAddrGapThreshold": {
           "type": "number",
           "default": 16,
           "multipleOf": 1,
@@ -276,7 +276,7 @@
           "maximum": 32,
           "description": "If the gap between registers is less than this threshold (multiple of 8), combine into a single read from device. -1 means never combine registers and is very slow"
         },
-        "svd-viewer.saveLayout": {
+        "peripheral-inspector.saveLayout": {
           "type": "boolean",
           "default": true,
           "description": "Save layout of peripheral view between sessions"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "peripheral-inspector",
   "displayName": "Peripheral Inspector",
-  "description": "Standalone SVD Viewer extension extracted from cortex-debug",
+  "description": "Standalone Peripheral Inspector extension extracted from cortex-debug",
   "version": "1.3.0",
   "preview": true,
   "publisher": "eclipse-cdt",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -6,8 +6,8 @@
  ********************************************************************************/
 
 export const PACKAGE_NAME = 'peripheral-inspector';
-export const CONFIG_SVD_PATH = 'svdPathConfig';
-export const DEFAULT_SVD_PATH = 'svdPath';
+export const CONFIG_SVD_PATH = 'definitionPathConfig';
+export const DEFAULT_SVD_PATH = 'definitionPath';
 export const CONFIG_DEVICE = 'deviceConfig';
 export const DEFAULT_DEVICE = 'deviceName';
 export const CONFIG_PROCESSOR = 'processorConfig';

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -5,7 +5,7 @@
  * terms of the MIT License as outlined in the LICENSE File
  ********************************************************************************/
 
-export const PACKAGE_NAME = 'svd-viewer';
+export const PACKAGE_NAME = 'peripheral-inspector';
 export const CONFIG_SVD_PATH = 'svdPathConfig';
 export const DEFAULT_SVD_PATH = 'svdPath';
 export const CONFIG_DEVICE = 'deviceConfig';

--- a/src/views/peripheral.ts
+++ b/src/views/peripheral.ts
@@ -250,7 +250,7 @@ export class PeripheralTreeForSession extends PeripheralBaseNode {
             this.peripherials.sort(PeripheralNode.compare);
             // this.fireCb();
         } catch(e) {
-            this.errMessage = `Unable to parse SVD file ${svdPath}: ${(e as Error).message}`;
+            this.errMessage = `Unable to parse definition file ${svdPath}: ${(e as Error).message}`;
             vscode.debug.activeDebugConsole.appendLine(this.errMessage);
             if (vscode.debug.activeDebugConsole) {
                 vscode.debug.activeDebugConsole.appendLine(this.errMessage);


### PR DESCRIPTION
This PR renames the extension to `Peripheral Inspector` and updates all extension IDs to `peripheral-inspector` as appropriate.
